### PR TITLE
DM-33198: Set up data file, schema, and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+
+'on':
+  push: {}
+  pull_request: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 'v4.1.0'
+    hooks:
+      - id: trailing-whitespace
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-json
+      - id: pretty-format-json
+        args: [--autofix, --indent=2, '--top-keys=name,doc,type']
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: 'v2.5.1' # Use the sha or tag you want to point at
+    hooks:
+      - id: prettier
+        types: [yaml]
+
+  - repo: https://github.com/sirosen/check-jsonschema
+    rev: '0.8.2'
+    hooks:
+      - id: check-jsonschema
+        name: 'Check GitHub Workflows'
+        files: ^\.github/workflows/
+        types: [yaml]
+        args: ['--schemafile', 'https://json.schemastore.org/github-workflow']
+
+      - id: check-jsonschema
+        name: 'Check metadata.yaml'
+        files: metadata\.yaml
+        types: [yaml]
+        args: ['--schemafile', 'schema.json']

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+singleQuote: true
+tabWidth: 2

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: init
+init:
+	pip install -U pre-commit
+	pre-commit install
+
+.PHONY: test
+test:
+	pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
 # doc-portal-prototype
+
 Prototype for the Rubin documentation portal to explore the metadata schema and organizational strategy. For the Documentation Working Group.
+
+This repository includes two key files:
+
+- `metadata.yaml` is a YAML-formatted file that contains the *metadata* about a representative set of Rubin documentation resources. This metadata is what will power the documentation portal: metadata can be used for display purposes, to enable organization and navigation, or to enable search.
+
+  Each array item in `metadata.yaml` is a separate, isolated, documentation resource.
+
+- `schema.json` is the *schema* for `metadata.yaml`; a schema defines the expected and allowed shape of a dataset. As we determine what information needs to be associated with document's metadata record, we need to add those new fields to `schema.json`. The tests for this repository continuously check that `metadata.yaml` conforms to `schema.json`.
+
+  The schema is written with [JSON Schema](https://json-schema.org). A great tutorial is available at [Understanding JSON Schema](https://json-schema.org/understanding-json-schema/index.html).
+
+Both of these files can become valuable resources for the Documentation Working Group: the `schema.json` file becomes a guide to what information needs to be collected to create a useful documentation portal experience, while `metadata.yaml` is a useful representative demo of the types of documentation we have that can power prototypes of the documentation portal.
+
+## Working with this repository: a primer
+
+*Working with this repository requires command line, Git and a GitHub account, and ideally a Python 3 installation as well.*
+
+Clone this repository:
+
+```sh
+git clone https://github.com/lsst-sitcom/doc-portal-prototype
+cd doc-portal-prototype
+```
+
+If you will be contributing changes, create a branch:
+
+```sh
+git checkout -b <branch-name>
+```
+
+Install the testing tools:
+
+```sh
+make init
+```
+
+Now, add a document to `metadata.yaml` or edit the schema in `schema.json`.
+At any time you can ensure the metadata conforms to the schema:
+
+```sh
+make test
+```
+
+Commit any changes, for example:
+
+```sh
+git add -a
+git commit
+```
+
+Note that the pre-commit tests run automatically at this point if you installed them (`make init`).
+If these pre-commit hooks reformatted any files, you'll need to re-add those changes files with `git add` and then try `git commit` again.
+
+You can create a new pull request on GitHub by running
+
+```sh
+git push -u
+```
+
+For more information about creating commits and pull requests, see the [GitHub documenation](https://docs.github.com/en/pull-requests).

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,9 @@
+- title: LSST Science Pipelines
+  description: |
+    The LSST Science Pipelines are designed to enable optical and
+    near-infrared astronomy in the “big data” era. While they are being
+    developed to process the data for the Rubin Observatory Legacy Survey
+    of Space and Time (Rubin’s LSST), our command line and programming
+    interfaces can be extended to address any optical or
+    near-infrared dataset.
+  url: https://pipelines.lsst.io/

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,30 @@
+{
+  "type": "array",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "items": {
+    "type": "object",
+    "properties": {
+      "dateUpdated": {
+        "type": "string",
+        "description": "The date and time when the document was last updated.",
+        "format": "date-time"
+      },
+      "description": {
+        "type": "string",
+        "description": "A description or summary of the document, useful for previewing"
+      },
+      "title": {
+        "type": "string",
+        "description": "The name of the document"
+      },
+      "url": {
+        "type": "string",
+        "description": "The main URL where the document can be accessed.",
+        "format": "uri"
+      }
+    },
+    "required": [
+      "title"
+    ]
+  }
+}


### PR DESCRIPTION
This PR sets up the prototyping platform.

- Data about document records goes in `metadata.yaml`
- The metadata schema is defined in `schema.json`
- The validation is run via pre-commit. Use the `make init` command to set up pre-commit for local development
- `.github/workflows/ci.yaml` ensures that PRs conform to the schema and have consistent formatting.