### PR TITLE
DM-33286: Develop schema for views

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,3 +14,5 @@
   departments:
     - Data Production
     - System Performance
+  systems:
+    - ['Data Production', 'LSST Science Pipelines']

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,3 +11,6 @@
   scmRepositoryUrl: https://github.com/lsst/pipelines_lsst_io
   storageRepository: lsst.io
   dateUpdated: '2020-01-01T00:00:00'
+  departments:
+    - Data Production
+    - System Performance

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,5 @@
-- title: LSST Science Pipelines
+- identifier: https://pipelines.lsst.io/
+  title: LSST Science Pipelines
   description: |
     The LSST Science Pipelines are designed to enable optical and
     near-infrared astronomy in the “big data” era. While they are being
@@ -7,3 +8,6 @@
     interfaces can be extended to address any optical or
     near-infrared dataset.
   url: https://pipelines.lsst.io/
+  scmRepositoryUrl: https://github.com/lsst/pipelines_lsst_io
+  storageRepository: lsst.io
+  dateUpdated: '2020-01-01T00:00:00'

--- a/schema.json
+++ b/schema.json
@@ -13,6 +13,32 @@
         "type": "string",
         "description": "A description or summary of the document, useful for previewing"
       },
+      "identifier": {
+        "type": "string",
+        "description": "A unique identifier for this document. If the document's storage repository uses a unique identifier, use that (for example, a DocuShare handle or a Jira item identifier). Otherwise, use the url as the identifier."
+      },
+      "scmRepositoryUrl": {
+        "type": "string",
+        "description": "The URL of the source code repository from which this document is generated, if available, if available.",
+        "format": "uri"
+      },
+      "seriesIdentifier": {
+        "type": "string",
+        "description": "The series this document is part of, if applicable. For example, a handle prefix (LDM)."
+      },
+      "storageRepository": {
+        "type": "string",
+        "description": "The document's primary storage repository. Specify null if the repository is unknown.",
+        "enum": [
+          null,
+          "lsst.io",
+          "docushare.lsstcorp.org",
+          "jira.lsstcorp.org",
+          "confluence.lsstcorp.org",
+          "euporie",
+          "pdm-vault"
+        ]
+      },
       "title": {
         "type": "string",
         "description": "The name of the document"
@@ -24,7 +50,10 @@
       }
     },
     "required": [
-      "title"
+      "identifier",
+      "title",
+      "url",
+      "storageRepository"
     ]
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -9,6 +9,19 @@
         "description": "The date and time when the document was last updated.",
         "format": "date-time"
       },
+      "departments": {
+        "type": "array",
+        "description": "The departments and/or teams that own the document.",
+        "items": {
+          "enum": [
+            "Rubin Observatory Operations",
+            "Data Production",
+            "System Performance",
+            "Education and Public Outreach",
+            "Director's Office"
+          ]
+        }
+      },
       "description": {
         "type": "string",
         "description": "A description or summary of the document, useful for previewing"

--- a/schema.json
+++ b/schema.json
@@ -52,6 +52,11 @@
           "pdm-vault"
         ]
       },
+      "systems": {
+        "type": "array",
+        "$ref": "./schema.systems.json",
+        "description": "The systems that this document refers to. A document can reference more than one system. Each system is described by an array of increasing specifificity."
+      },
       "title": {
         "type": "string",
         "description": "The name of the document"

--- a/schema.json
+++ b/schema.json
@@ -15,6 +15,7 @@
         "items": {
           "enum": [
             "Rubin Observatory Operations",
+            "Camera",
             "Data Production",
             "System Performance",
             "Education and Public Outreach",

--- a/schema.systems.json
+++ b/schema.systems.json
@@ -1,0 +1,508 @@
+{
+  "$defs": {
+    "systemTags": {
+      "enum": [
+        [
+          "Data Production"
+        ],
+        [
+          "Data Production",
+          "LSST Science Pipelines"
+        ],
+        [
+          "Data Production",
+          "Rubin Science Platform"
+        ],
+        [
+          "Data Production",
+          "Rubin Science Platform",
+          "Nublado"
+        ],
+        [
+          "Data Production",
+          "Rubin Science Platform",
+          "Gafaelfawr"
+        ],
+        [
+          "Data Production",
+          "Rubin Science Platform",
+          "Phalanx"
+        ],
+        [
+          "Data Production",
+          "Rubin Science Platform",
+          "Moneypenny"
+        ],
+        [
+          "Data Production",
+          "Rubin Science Platform",
+          "Squareone"
+        ],
+        [
+          "Summit Site"
+        ],
+        [
+          "Summit Site",
+          "AuxTel"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Ventilation Gates"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Ventilation Gates",
+          "Fans"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Ventilation Gates",
+          "Fans",
+          "Fan Control"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Ventilation Gates",
+          "Fans",
+          "Air Extracting System"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Pneumatic System"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Pneumatic System",
+          "Air Compressor"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Instrument Hoist"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Electronic Cabinet"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Main Door"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Upper Shutter"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Upper Shutter",
+          "Motor"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Lower Shutter"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Lower Shutter",
+          "Motor"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Azimuthal Rotator"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Calibration Equipment"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Calibration Equipment",
+          "Flat-Field Screen"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Calibration Equipment",
+          "Flat-Field Screen",
+          "Coating"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Calibration Equipment",
+          "Flat-Field Screen",
+          "Tunable Laser"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Calibration Equipment",
+          "Lighting Source"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Calibration Equipment",
+          "Monochromator"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Controller"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Compact Rio"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "KollMorgan Motors Controllers"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "PDU"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Power Supply"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Dome",
+          "Power Supply",
+          "UPS"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Kiloarc IR Filter water chiller"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Cryotiger Compressor"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "Air Compressor"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Building",
+          "KVM Station"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Telescope"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Telescope",
+          "AuxTel Camera"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Telescope",
+          "Mirrors"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Telescope",
+          "Mirrors",
+          "Primary"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Telescope",
+          "Mirrors",
+          "Secondary"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Telescope",
+          "Mirrors",
+          "Tertiary"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Telescope",
+          "Mount"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Telescope",
+          "Mount",
+          "Support System"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Telescope",
+          "Mount",
+          "Mirror Cover"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Telescope",
+          "Mount",
+          "Control System"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Spectrograph"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Spectrograph",
+          "Protective Frame"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Spectrograph",
+          "Cable Drum"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Spectrograph"
+        ],
+        [
+          "Summit Site",
+          "AuxTel",
+          "Integration Lab"
+        ],
+        [
+          "Summit Site",
+          "Simonyi"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Structure"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Rotation Enclosure"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Azimuth Rotation"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Aperture Shutters"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Thermal Ventilation"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Heat Control"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Light Wind Screens"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Rear Access Door"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Louvers"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Bridge Camera"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Access"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome",
+          "Dome Control System"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Calibration System"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Calibration System",
+          "Beam Projector"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Calibration System",
+          "Laser System"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Calibration System",
+          "White Light Sources"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Calibration System",
+          "Fiber Spectrographs"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Calibration System",
+          "Electrometer"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Calibration System",
+          "Calibration Screen"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome Bridge Crane"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome Bridge Crane",
+          "Temporary Crane"
+        ],
+        [
+          "Summit Site",
+          "Simonyi",
+          "Dome Bridge Crane",
+          "Crane Hook"
+        ]
+      ]
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}


### PR DESCRIPTION
This commit generally develops the schema with an eye towards fulfilling the needs of the portal views:

- access view
- product view
- storage view
- topic view

New schema fields are:

- departments
- identifier
- scmRepositoryUrl
- seriesIdentifier
- storageRepositry
- systems